### PR TITLE
文字数カウント機能のサーバーサイド

### DIFF
--- a/app/javascript/count.js
+++ b/app/javascript/count.js
@@ -1,0 +1,10 @@
+function count (){
+  const articleText = document.getElementById("article_text");
+  articleText.addEventListener("keyup", (e) => {
+    const countVal = articleText.value.length;
+    const charNum = document.getElementById("char_num");
+    charNum.innerHTML = `${countVal}文字`;
+  });
+}
+
+window.addEventListener("load", count)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../post")
+require("../count")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)


### PR DESCRIPTION
# What
count.jsファイルの記述

# Why
フォームに入力した文字数が自動で表示されるようにするため